### PR TITLE
Fix lint warning

### DIFF
--- a/packages/webpack/webpack.config.js
+++ b/packages/webpack/webpack.config.js
@@ -5,6 +5,16 @@ const webpack = require('webpack')
 const path = require('path')
 const nodeExternals = require('webpack-node-externals')
 
+const getSecretConfigEnvs = (slsw) => {
+	const { custom } = slsw.lib.serverless.service
+	const secretConfigEnvs =
+		custom && custom.secretConfigEnvs ? custom.secretConfigEnvs : {}
+
+	return {
+		'process.env.__SECRETS__': JSON.stringify(secretConfigEnvs)
+	}
+}
+
 module.exports = (slsw, dirname) => {
 	return {
 		context: dirname,
@@ -46,15 +56,5 @@ module.exports = (slsw, dirname) => {
 			new webpack.IgnorePlugin(/^pg-native$/),
 			new webpack.DefinePlugin({ ...getSecretConfigEnvs(slsw) })
 		]
-	}
-}
-
-const getSecretConfigEnvs = (slsw) => {
-	const { custom } = slsw.lib.serverless.service
-	const secretConfigEnvs =
-		custom && custom.secretConfigEnvs ? custom.secretConfigEnvs : {}
-
-	return {
-		'process.env.__SECRETS__': JSON.stringify(secretConfigEnvs)
 	}
 }


### PR DESCRIPTION
## Description

Fix lint warning

```
warning  'getSecretConfigEnvs' was used before it was defined  @typescript-eslint/no-use-before-define
```

## Pull request checklist

### For feature development:
- [x] Have you tested your code?
- [x] Did you commit only code related to your feature?
- [x] Are you sure you did not break any other feature?
- [x] Have you checked your PR before you assigned it to reviewer(s)?
- [x] Are you sure your feature does not contain any hacks?
