### PR TITLE
ci: add conditional AWS_ROLE environment variable

### DIFF
--- a/.circleci/aws_assume_role.sh
+++ b/.circleci/aws_assume_role.sh
@@ -1,7 +1,13 @@
 unset AWS_SESSION_TOKEN
 
 PROJECT_NAME=$(yq e '.common.projectName' serverless.settings.yml)
-AWS_ROLE=$(yq e '.ci.awsRole' serverless.settings.yml)
+
+if [ $CIRCLE_BRANCH = 'master' ]
+then
+    AWS_ROLE=$(yq e '.ci.prodAwsRole' serverless.settings.yml)
+else
+    AWS_ROLE=$(yq e '.ci.stagingAwsRole' serverless.settings.yml)
+fi
 
 temp_role=$(aws sts assume-role --role-arn $AWS_ROLE --role-session-name $PROJECT_NAME)
 

--- a/serverless.settings.yml
+++ b/serverless.settings.yml
@@ -9,7 +9,8 @@ common:
   apiGatewayShouldStartNameWithService: true # https://www.serverless.com/framework/docs/deprecations/#AWS_API_GATEWAY_NAME_STARTING_WITH_SERVICE
 
 ci:
-  awsRole: arn:aws:iam::000000000000:role/ReplaceCiRole
+  prodAwsRole: arn:aws:iam::000000000000:role/ReplaceCiRole
+  stagingAwsRole: arn:aws:iam::000000000000:role/ReplaceCiRole
 
 vpc: ~
   # securityGroupIds:


### PR DESCRIPTION
- We can infer the AWS_ROLE based on the current circleci branch
- $CIRCLE_BRANCH is a prepopulated environment variable with the branch name
- This means we don't need to explicitly pass aws_role in circleci config as its set dynamically
