### PR TITLE
ci: add commit linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,11 @@ jobs:
       - run: *commands_npm_auth
       - run: *install_dependencies
       - run:
-          name: Run Linter
+          name: Run Commit Linter
+          # The commit hash since when the history is checked
+          command: npx commitlint --from e20ae1d8d7e47409d6e10cf1ab9bb6374e7e53a0 --to HEAD
+      - run:
+          name: Run Code Linter
           command: npm run lint
       - run:
           name: Graphql CodeGen check


### PR DESCRIPTION
## Description

Add commit linting also to CI.

I have picked the last commit ( https://github.com/purple-technology/purple-stack/commit/e20ae1d8d7e47409d6e10cf1ab9bb6374e7e53a0 ) as a reference point since when all the commits will be checked. Because otherwise it checked the whole history which obviously failed because we didn't use conventional commits from the beginning.
