### PR TITLE
chore(frontend): remove babel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ lerna-debug.log
 
 # VS code
 .vscode/launch.json
+
+# Next.js generates this automatically
+next-env.d.ts

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": [["styled-components", { "ssr": true }]]
-}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3948,74 +3948,74 @@
 			"dev": true
 		},
 		"@next/env": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
-			"integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.0.tgz",
+			"integrity": "sha512-nrIgY6t17FQ9xxwH3jj0a6EOiQ/WDHUos35Hghtr+SWN/ntHIQ7UpuvSi0vaLzZVHQWaDupKI+liO5vANcDeTQ=="
 		},
 		"@next/swc-android-arm64": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.10.tgz",
-			"integrity": "sha512-xYwXGkNhzZZsM5MD7KRwF5ZNiC8OLPtVMUiagpPnwENg8Hb0GSQo/NbYWXM8YrawEwp9LaZ7OXiuRKPh2JyBdA==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.0.tgz",
+			"integrity": "sha512-/280MLdZe0W03stA69iL+v6I+J1ascrQ6FrXBlXGCsGzrfMaGr7fskMa0T5AhQIVQD4nA/46QQWxG//DYuFBcA==",
 			"optional": true
 		},
 		"@next/swc-darwin-arm64": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz",
-			"integrity": "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.0.tgz",
+			"integrity": "sha512-R8vcXE2/iONJ1Unf5Ptqjk6LRW3bggH+8drNkkzH4FLEQkHtELhvcmJwkXcuipyQCsIakldAXhRbZmm3YN1vXg==",
 			"optional": true
 		},
 		"@next/swc-darwin-x64": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz",
-			"integrity": "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.0.tgz",
+			"integrity": "sha512-ieAz0/J0PhmbZBB8+EA/JGdhRHBogF8BWaeqR7hwveb6SYEIJaDNQy0I+ZN8gF8hLj63bEDxJAs/cEhdnTq+ug==",
 			"optional": true
 		},
 		"@next/swc-linux-arm-gnueabihf": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.10.tgz",
-			"integrity": "sha512-EhqrTFsIXAXN9B/fiiW/QKUK/lSLCXRsLalkUp58KDfMqVLLlj1ORbESAcswiNQOChLuHQSldGEEtOBPQZcd9A==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.0.tgz",
+			"integrity": "sha512-njUd9hpl6o6A5d08dC0cKAgXKCzm5fFtgGe6i0eko8IAdtAPbtHxtpre3VeSxdZvuGFh+hb0REySQP9T1ttkog==",
 			"optional": true
 		},
 		"@next/swc-linux-arm64-gnu": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.10.tgz",
-			"integrity": "sha512-kqGtC72g3+JYXZbY2ca6digXR5U6AQ6Dzv4eAxYluMePLHjI/Xye1mf9dwVsgmeXfrD/IRDp5K/3A6UNvBm4oQ==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.0.tgz",
+			"integrity": "sha512-OqangJLkRxVxMhDtcb7Qn1xjzFA3s50EIxY7mljbSCLybU+sByPaWAHY4px97ieOlr2y4S0xdPKkQ3BCAwyo6Q==",
 			"optional": true
 		},
 		"@next/swc-linux-arm64-musl": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.10.tgz",
-			"integrity": "sha512-bG9zTSNwnSgc1Un/7oz1ZVN4UeXsTWrsQhAGWU78lLLCn4Zj9HQoUCRCGLt0OVs2DBZ+WC8CzzFliQ1SKipVbg==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.0.tgz",
+			"integrity": "sha512-hB8cLSt4GdmOpcwRe2UzI5UWn6HHO/vLkr5OTuNvCJ5xGDwpPXelVkYW/0+C3g5axbDW2Tym4S+MQCkkH9QfWA==",
 			"optional": true
 		},
 		"@next/swc-linux-x64-gnu": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.10.tgz",
-			"integrity": "sha512-c79PcfWtyThiYRa1+3KVfDq0zXaI8o1d6dQWNVqDrtLz5HKM/rbjLdvoNuxDwUeZhxI/d9CtyH6GbuKPw5l/5A==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.0.tgz",
+			"integrity": "sha512-OKO4R/digvrVuweSw/uBM4nSdyzsBV5EwkUeeG4KVpkIZEe64ZwRpnFB65bC6hGwxIBnTv5NMSnJ+0K/WmG78A==",
 			"optional": true
 		},
 		"@next/swc-linux-x64-musl": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.10.tgz",
-			"integrity": "sha512-g/scgn+21/MLfizOCZOZt+MxNj2/8Tdlwjvy+QZcSUPZRUI2Y5o3HwBvI1f/bSci+NGRU+bUAO0NFtRJ9MzH5w==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.0.tgz",
+			"integrity": "sha512-JohhgAHZvOD3rQY7tlp7NlmvtvYHBYgY0x5ZCecUT6eCCcl9lv6iV3nfu82ErkxNk1H893fqH0FUpznZ/H3pSw==",
 			"optional": true
 		},
 		"@next/swc-win32-arm64-msvc": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.10.tgz",
-			"integrity": "sha512-gl6B/ravwMeY5Nv4Il2/ARYJQ6u+KPRwGMjS1ZrNudIKlNn4YBeXh5A4cIVm+dHaff6/O/lGOa5/SUYDMZpkww==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.0.tgz",
+			"integrity": "sha512-T/3gIE6QEfKIJ4dmJk75v9hhNiYZhQYAoYm4iVo1TgcsuaKLFa+zMPh4056AHiG6n9tn2UQ1CFE8EoybEsqsSw==",
 			"optional": true
 		},
 		"@next/swc-win32-ia32-msvc": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.10.tgz",
-			"integrity": "sha512-7RVpZ3tSThC6j+iZB0CUYmFiA3kXmN+pE7QcfyAxFaflKlaZoWNMKHIEZDuxSJc6YmQ6kyxsjqxVay2F5+/YCg==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.0.tgz",
+			"integrity": "sha512-iwnKgHJdqhIW19H9PRPM9j55V6RdcOo6rX+5imx832BCWzkDbyomWnlzBfr6ByUYfhohb8QuH4hSGEikpPqI0Q==",
 			"optional": true
 		},
 		"@next/swc-win32-x64-msvc": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.10.tgz",
-			"integrity": "sha512-oUIWRKd24jFLRWUYO1CZmML5+32BcpVfqhimGaaZIXcOkfQW+iqiAzdqsv688zaGtyKGeB9ZtiK3NDf+Q0v+Vw==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.0.tgz",
+			"integrity": "sha512-aBvcbMwuanDH4EMrL2TthNJy+4nP59Bimn8egqv6GHMVj0a44cU6Au4PjOhLNqEh9l+IpRGBqMTzec94UdC5xg==",
 			"optional": true
 		},
 		"@nodelib/fs.scandir": {
@@ -5689,9 +5689,9 @@
 			"integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001309",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
-			"integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA=="
+			"version": "1.0.30001313",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
+			"integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q=="
 		},
 		"chainsaw": {
 			"version": "0.1.0",
@@ -8475,22 +8475,22 @@
 			"dev": true
 		},
 		"next": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
-			"integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/next/-/next-12.1.0.tgz",
+			"integrity": "sha512-s885kWvnIlxsUFHq9UGyIyLiuD0G3BUC/xrH0CEnH5lHEWkwQcHOORgbDF0hbrW9vr/7am4ETfX4A7M6DjrE7Q==",
 			"requires": {
-				"@next/env": "12.0.10",
-				"@next/swc-android-arm64": "12.0.10",
-				"@next/swc-darwin-arm64": "12.0.10",
-				"@next/swc-darwin-x64": "12.0.10",
-				"@next/swc-linux-arm-gnueabihf": "12.0.10",
-				"@next/swc-linux-arm64-gnu": "12.0.10",
-				"@next/swc-linux-arm64-musl": "12.0.10",
-				"@next/swc-linux-x64-gnu": "12.0.10",
-				"@next/swc-linux-x64-musl": "12.0.10",
-				"@next/swc-win32-arm64-msvc": "12.0.10",
-				"@next/swc-win32-ia32-msvc": "12.0.10",
-				"@next/swc-win32-x64-msvc": "12.0.10",
+				"@next/env": "12.1.0",
+				"@next/swc-android-arm64": "12.1.0",
+				"@next/swc-darwin-arm64": "12.1.0",
+				"@next/swc-darwin-x64": "12.1.0",
+				"@next/swc-linux-arm-gnueabihf": "12.1.0",
+				"@next/swc-linux-arm64-gnu": "12.1.0",
+				"@next/swc-linux-arm64-musl": "12.1.0",
+				"@next/swc-linux-x64-gnu": "12.1.0",
+				"@next/swc-linux-x64-musl": "12.1.0",
+				"@next/swc-win32-arm64-msvc": "12.1.0",
+				"@next/swc-win32-ia32-msvc": "12.1.0",
+				"@next/swc-win32-x64-msvc": "12.1.0",
 				"caniuse-lite": "^1.0.30001283",
 				"postcss": "8.4.5",
 				"styled-jsx": "5.0.0",
@@ -8894,9 +8894,9 @@
 			},
 			"dependencies": {
 				"nanoid": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-					"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+					"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw=="
 				}
 			}
 		},

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
 		"graphql": "15.8.0",
 		"graphql-tag": "2.12.6",
 		"i18next": "21.6.13",
-		"next": "^12.0.10",
+		"next": "^12.1.0",
 		"react": "17.0.2",
 		"react-i18next": "11.15.5",
 		"styled-components": "5.3.3"
@@ -44,7 +44,6 @@
 		"@types/react": "17.0.39",
 		"@types/react-dom": "17.0.13",
 		"@types/styled-components": "5.1.24",
-		"babel-plugin-styled-components": "2.0.6",
 		"env-cmd": "^10.1.0",
 		"react-dom": "17.0.2",
 		"serve": "^13.0.0",


### PR DESCRIPTION
## Description

We can use the new Next.js compiler. The only custom-ish thing we have with babel is Styled Components and SWC supports that out of the box.

